### PR TITLE
fix gpu param passing, add parameter requires_grad check

### DIFF
--- a/pytorch_influence_functions/calc_influence_function.py
+++ b/pytorch_influence_functions/calc_influence_function.py
@@ -458,7 +458,7 @@ def calc_img_wise(config, model, train_loader, test_loader):
 
         start_time = time.time()
         influence, harmful, helpful, _ = calc_influence_single(
-            model, train_loader, test_loader, test_id_num=i, gpu=0,
+            model, train_loader, test_loader, test_id_num=i, gpu=config['gpu'],
             recursion_depth=config['recursion_depth'], r=config['r_averaging'])
         end_time = time.time()
 

--- a/pytorch_influence_functions/influence_function.py
+++ b/pytorch_influence_functions/influence_function.py
@@ -43,7 +43,8 @@ def s_test(z_test, t_test, model, z_loader, gpu=-1, damp=0.01, scale=25.0,
                 x, t = x.cuda(), t.cuda()
             y = model(x)
             loss = calc_loss(y, t)
-            hv = hvp(loss, list(model.parameters()), h_estimate)
+            params = [ p for p in model.parameters() if p.requires_grad ]
+            hv = hvp(loss, params, h_estimate)
             # Recursively caclulate h_estimate
             h_estimate = [
                 _v + (1 - damp) * _h_e - _hv / scale
@@ -93,7 +94,8 @@ def grad_z(z, t, model, gpu=-1):
     y = model(z)
     loss = calc_loss(y, t)
     # Compute sum of gradients from model parameters to loss
-    return list(grad(loss, list(model.parameters()), create_graph=True))
+    params = [ p for p in model.parameters() if p.requires_grad ]
+    return list(grad(loss, params, create_graph=True))
 
 
 def hvp(y, w, v):


### PR DESCRIPTION
Hello, thanks for releasing this code. I ran into a couple of issues, one is simply a parameter passing bug. The other is due to some of my model's parameters are frozen/not trained, so I added a requires_grad=True check. Otherwise users would run into such an error:

```
...
    ptif.calc_img_wise(config, model, train_loader, test_loader)
  File ".../pytorch_influence_functions/calc_influence_function.py", line 462, in calc_img_wise
    recursion_depth=config['recursion_depth'], r=config['r_averaging'])
  File ".../pytorch_influence_functions/calc_influence_function.py", line 317, in calc_influence_s\
ingle
    r=r)
  File ".../pytorch_influence_functions/calc_influence_function.py", line 95, in calc_s_test_singl\
e
    recursion_depth=recursion_depth))
  File ".../pytorch_influence_functions/influence_function.py", line 28, in s_test
    v = grad_z(z_test, t_test, model, gpu)
  File ".../pytorch_influence_functions/influence_function.py", line 96, in grad_z
    return list(grad(loss, list(model.parameters()), create_graph=True))
  File ".../python3.6/site-packages/torch/autograd/__init__.py", line 157, in grad
    inputs, allow_unused)
RuntimeError: One of the differentiated Tensors does not require grad
```